### PR TITLE
Добавление бронежилета в ведор с бронёй

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1185,6 +1185,7 @@
 		"General" = list(
 			/obj/item/clothing/suit/modular = -1,
 			/obj/item/clothing/suit/modular/rownin = -1,
+			/obj/item/clothing/suit/armor/bulletproof = -1,
 			/obj/item/facepaint/green = -1,
 			/obj/item/facepaint/sniper = -1,
 			/obj/item/facepaint/black = -1,


### PR DESCRIPTION
## `Основные изменения`
Добавляет бронежилет в вендор с броней во вкладку "General".

## `Как это улучшит игру`
Даёт маринам, которые жертвуют фонариком ради минимальной брони с скоростью возможность носить оружие на слоте верхней одежды +выглядит минималистично и подойдёт под множество лодаутов

## `Ченджлог`
```
:cl:
add: В вендоре с бронёй появился пуленепробиваемый бронежилет.
/:cl:
```
