### PR TITLE
Shrapnel amount from xenomorph explosion gib now correlates with the mob size. Spiderlings are now human sized.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -7,6 +7,7 @@
 	health = 150
 	maxHealth = 150
 	plasma_stored = 200
+	mob_size = MOB_SIZE_HUMAN
 	tier = XENO_TIER_MINION
 	upgrade = XENO_UPGRADE_BASETYPE
 	pull_speed = -2

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -34,7 +34,8 @@
 	if(severity >= max(health, EXPLOSION_THRESHOLD_GIB + get_soft_armor(BOMB) * 2))
 		var/oldloc = loc
 		gib()
-		create_shrapnel(oldloc, rand(8, 16), direction, shrapnel_type = /datum/ammo/bullet/shrapnel/light/xeno)
+		if(mob_size > MOB_SIZE_SMALL) // cause the size is 0 and will cause errors
+			create_shrapnel(oldloc, rand(4, 8) * mob_size, direction, shrapnel_type = /datum/ammo/bullet/shrapnel/light/xeno)
 		return
 
 	apply_damages(severity * 0.5, severity * 0.5, blocked = BOMB, updating_health = TRUE)


### PR DESCRIPTION
## `Основные изменения`
Количество шрапнели появляющейся после гиба ксеноморфа взрывом теперь коррелирует с размером самого ксеноса. Чем больше ксенос - тем больше шрапнели.
Возможно конечно потом будут с кол-вом шрапнели и происходящим из этого лага, но это можно будет ограничить потом.
## `Как это улучшит игру`
Реализм. xd
## `Ченджлог`
```
:cl:
balance: Количество шрапнели появляющейся после гиба ксеноморфа взрывом теперь коррелирует с размером самого ксеноса. Чем больше ксенос - тем больше шрапнели.
balance: Паучата вдовы теперь размером с людей.
/:cl:
```
