### PR TITLE
Пойнтер в field utility pouch

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -806,6 +806,7 @@
 		/obj/item/toy/deck,
 		/obj/item/paper,
 		/obj/item/clipboard,
+		/obj/item/pinpointer,
 	))
 
 /obj/item/storage/pouch/field_pouch/full/PopulateContents()


### PR DESCRIPTION
## `Основные изменения`

Теперь в field utility pouch можно класть пойнтер.

## `Как это улучшит игру`

Удобно и логично. В описании пауча написано, что в нём можно хранить навигацию.

## `Ченджлог`

```
:cl:
balance: В field utility pouch теперь можно положить пойнтер
/:cl:
```
