### PR TITLE
Restricts revolving rifle from being inserted in sidearm holsters.

### DIFF
--- a/code/datums/storage/subtypes/holster.dm
+++ b/code/datums/storage/subtypes/holster.dm
@@ -227,10 +227,15 @@
 
 /datum/storage/holster/belt/m44/New(atom/parent)
 	. = ..()
-	set_holdable(can_hold_list = list(
-		/obj/item/weapon/gun/revolver,
-		/obj/item/ammo_magazine/revolver,
-	))
+	set_holdable(
+		can_hold_list = list(
+			/obj/item/weapon/gun/revolver,
+			/obj/item/ammo_magazine/revolver,
+		),
+		cant_hold_list = list(
+			/obj/item/weapon/gun/revolver/coltrifle,
+		)
+	)
 
 /datum/storage/holster/belt/mateba
 	max_storage_space = 16

--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -158,14 +158,19 @@
 
 /datum/storage/internal/holster/New(atom/parent)
 	. = ..()
-	set_holdable(can_hold_list = list(
-		/obj/item/weapon/gun/pistol,
-		/obj/item/ammo_magazine/pistol,
-		/obj/item/weapon/gun/revolver,
-		/obj/item/ammo_magazine/revolver,
-		/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol,
-		/obj/item/cell/lasgun/lasrifle,
-	))
+	set_holdable(
+		can_hold_list = list(
+			/obj/item/weapon/gun/pistol,
+			/obj/item/ammo_magazine/pistol,
+			/obj/item/weapon/gun/revolver,
+			/obj/item/ammo_magazine/revolver,
+			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol,
+			/obj/item/cell/lasgun/lasrifle,
+		),
+		cant_hold_list = list(
+			/obj/item/weapon/gun/revolver/coltrifle,
+		)
+	)
 	storage_type_limits_max = list(/obj/item/weapon/gun = 1)
 
 /datum/storage/internal/modular

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -669,10 +669,15 @@
 	storage_datum.storage_type_limits = list(
 		/obj/item/weapon/gun/revolver,
 	)
-	storage_datum.set_holdable(can_hold_list = list(
-		/obj/item/weapon/gun/revolver,
-		/obj/item/ammo_magazine/revolver,
-	))
+	storage_datum.set_holdable(
+		can_hold_list = list(
+			/obj/item/weapon/gun/revolver,
+			/obj/item/ammo_magazine/revolver,
+		),
+		cant_hold_list = list(
+			/obj/item/weapon/gun/revolver/coltrifle,
+		)
+	)
 
 /obj/item/storage/holster/belt/revolver/t500
 	name = "\improper BM500 pattern BF revolver holster rig"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -215,15 +215,20 @@
 	storage_datum.sprite_slots = 1
 	storage_datum.max_w_class = WEIGHT_CLASS_BULKY
 	storage_datum.draw_mode = FALSE
-	storage_datum.set_holdable(can_hold_list = list(
-		/obj/item/weapon/gun/pistol,
-		/obj/item/ammo_magazine/pistol,
-		/obj/item/weapon/gun/revolver,
-		/obj/item/ammo_magazine/revolver,
-		/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol,
-		/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/serpenta,
-		/obj/item/cell/lasgun/lasrifle,
-	))
+	storage_datum.set_holdable(
+		can_hold_list = list(
+			/obj/item/weapon/gun/pistol,
+			/obj/item/ammo_magazine/pistol,
+			/obj/item/weapon/gun/revolver,
+			/obj/item/ammo_magazine/revolver,
+			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol,
+			/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/serpenta,
+			/obj/item/cell/lasgun/lasrifle,
+		),
+		cant_hold_list = list(
+			/obj/item/weapon/gun/revolver/coltrifle,
+		)
+	)
 
 /obj/item/storage/pouch/pistol/vp70/PopulateContents()
 	new /obj/item/weapon/gun/pistol/vp70(src)


### PR DESCRIPTION
## `Основные изменения`
Револвинг рифл теперь нельзя положить в подсумки для вторичного оружия.
## `Ченджлог`
```
:cl:
fix: Револвинг рифл теперь нельзя положить в подсумки для вторичного оружия.
/:cl:
```
