### PR TITLE
Add TerraGov standart flak jacket to marine point vendor

### DIFF
--- a/code/__DEFINES/loadout/gear/marine.dm
+++ b/code/__DEFINES/loadout/gear/marine.dm
@@ -1,4 +1,5 @@
 GLOBAL_LIST_INIT(marine_gear_listed_products, list(
+	/obj/item/clothing/suit/modular/xenonauten/pilot = list(CAT_MARINE, "TerraGov standard flak jacket", 20, "red"),
 	/obj/item/implanter/skill/firearms = list(CAT_MARINE, "Firearms skills implanter", 35, "cyan2"),
 	/obj/item/implanter/skill/melee = list(CAT_MARINE, "CQC skills implanter", 25, "cyan2"),
 	/obj/item/implanter/skill/medical = list(CAT_MARINE, "Medical skills implanter", 20, "cyan2"),


### PR DESCRIPTION
## `Основные изменения`

Добавляет TerraGov standard flak jacket в вендор маринов за поинты 

## `Как это улучшит игру`
Появление аналога Б12 с ЦМов у маринов: броня с защитой хэви и замедлением медиума

## `Ченджлог`

```
:cl:
add: Добавил TerraGov standard flak jacket в вендор за поинты
balance: Добавил TerraGov standard flak jacket в вендор за поинты
/:cl:
```
