### PR TITLE
Звук затвора

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1304,9 +1304,7 @@
 			var/obj/item/ammo_magazine/magazine = new_mag
 			magazine.on_inserted(src)
 		if(!in_chamber && !CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION) && !CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE))
-			spawn()
-				sleep(1 SECONDS)
-				playsound(src, cocked_sound, 25, 1)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), src, cocked_sound, 25, 1), 1 SECONDS)
 			cycle(user, FALSE)
 		update_ammo_count()
 		update_icon()


### PR DESCRIPTION
## `Основные изменения`

Теперь после полной перезарядки (когда патронник пустой) проигрывается звук передёргивания затвора

https://github.com/user-attachments/assets/f5ff33f9-4199-4338-86d2-a6cc1f0cd07d

## `Как это улучшит игру`

Иммерсивно, логично. Почти что у каждой, если не у каждой пушки, свой звук затвора, а слышат его примерно раз в никогда.

## `Ченджлог`

```
:cl:
add: Теперь после полной перезарядки проигрывается звук передёргивания затвора.
/:cl:
```
