### PR TITLE
Marine AK's balancing

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -762,7 +762,7 @@
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
 	attachable_offset = list("muzzle_x" = 35, "muzzle_y" = 18,"rail_x" = 6, "rail_y" = 20, "under_x" = 19, "under_y" = 14, "stock_x" = 5, "stock_y" = 12)
 	starting_attachment_types = list(/obj/item/attachable/stock/mpi_km)
-	damage_falloff_mult = 0.4
+	damage_falloff_mult = 0.6
 	force = 20
 	burst_amount = 2
 	autoburst_delay = 0.1 SECONDS


### PR DESCRIPTION
## `Основные изменения`

Уменьшение скорострельности у обоих версий мариновских калашей, уменьшение falloff у Зари и без возможности нацепить подствольный гранатомет/дробовик на неё же

## `Как это улучшит игру`

В данный момент обе версии AK на голову выше стандартных морпеховских винтовок. Нерф рифлы со скорострельностью и мувспидом ППшки.

Скриншоты с ДПС калькулятора

<img width="2356" height="425" alt="image1" src="https://github.com/user-attachments/assets/c9f45ed7-dd3b-4445-b188-8c32aac93f83" />
<img width="2361" height="425" alt="image2" src="https://github.com/user-attachments/assets/5e532267-d6a0-443a-97a5-65654f299ac1" />
<img width="2359" height="416" alt="image3" src="https://github.com/user-attachments/assets/dfafad3a-82ff-4d69-8b3b-7b0fb6935cff" />
<img width="2358" height="412" alt="image4" src="https://github.com/user-attachments/assets/f6d22cdd-b8a0-4bf6-bda3-d747bea96392" />


## `Ченджлог`

```
:cl:
balance: Баланс калашей.
/:cl:
```