### PR TITLE
Buldur buff

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -32,7 +32,7 @@
 	icon_state = "mod_lamp"
 	worn_icon_state = "mod_lamp_a"
 	slowdown = 0
-	light_mod = 4 /// The boost to armor shoulder light
+	light_mod = 8 /// The boost to armor shoulder light
 	slot = ATTACHMENT_SLOT_MODULE
 
 /**


### PR DESCRIPTION
## `Основные изменения`

Бафф балдура  light_mod 4 ->8.

## `Как это улучшит игру`

Карманный пистолетик светит лучше чем целый модуль на броню, криндж
Балдур будет не говном

## `Ченджлог`
```
:cl:
balance: Бафф балдура  light_mod 4 -> 8.
/:cl:
```
