### PR TITLE
Небольшой бафф химеры

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -25,7 +25,7 @@
 	)
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_LAST_STAND)
 
-	restricted_castes = list(/datum/xeno_caste/ravager, /datum/xeno_caste/hivemind)
+	restricted_castes = list(/datum/xeno_caste/ravager, /datum/xeno_caste/hivemind, /datum/xeno_caste/chimera)
 
 	bioscan_interval = 0
 	// Round end conditions

--- a/code/modules/mob/living/carbon/xenomorph/castes/chimera/castedatum_chimera.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/chimera/castedatum_chimera.dm
@@ -34,8 +34,6 @@
 	blink_drag_friendly_multiplier = 4
 	blink_range = 5
 
-	evolve_min_xenos = 8
-
 	minimap_icon = "chimera"
 
 	// *** Abilities *** //


### PR DESCRIPTION
## `Основные изменения`

ХП: 350 -> 400
Crippling Strike перенесён из примо в базовые способности
Phantom перенесён из базовой способности в примо
ХП Фантома увеличено 150 ->200
Броня Фантому увеличена 0 -> 15% (для пуль, лазеров и ближнего боя)

## `Как это улучшит игру`

Очень слабый Т3 которыйбез примо играется только против одиночек и маленьких групп. Перенеся примо в базовый кит, и увеличив здоровье, она становится более способной и опасной против унгаболла.

## `Ченджлог`
```
:cl:
balance: Бафф Химеры
/:cl:
```
