### PR TITLE
Wall Balance

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -213,4 +213,4 @@
 	icon_state = "resin-wall-0"
 	walltype = "resin-wall"
 	base_icon_state = "resin-wall"
-	soft_armor = list(MELEE = 80, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 80, BIO = 0, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 80, BULLET = 20, LASER = 35, ENERGY = 35, BOMB = 80, BIO = 0, FIRE = 0, ACID = 0)


### PR DESCRIPTION
## `Основные изменения`

Кто-то решил навертеть баланс стенам так, чтобы у них было разное максимальное здоровье и огромные плюсы к броне, теперь всё более-менее прозрачно, у стен одинаковое количество ХП + у каждого типа стен свой минус, а броня не сильно лучше базовых стен (Кто-то вообще использует базовые стены?).

У bulletproof и fireproof стен теперь по 300 макс хп, как и у остальных (Было 200)

.
<img width="1933" height="905" alt="image" src="https://github.com/user-attachments/assets/04c70c3e-28ca-4c00-91fc-8c3a67a838f9" />

## `Как это улучшит игру`

Ксенонёрф, базовые стенки как не ставили так и не будут ставить
Если есть идеи как вернуть к жизни базовые стенки пишите мне на онлифанс

## `Ченджлог`
```
:cl:
balance: У особых стен больше здоровья, но меньше софт армора.
/:cl:
```
