### PR TITLE
Gl54 and ar55 fix

### DIFF
--- a/code/modules/projectiles/ammo_datums/misc.dm
+++ b/code/modules/projectiles/ammo_datums/misc.dm
@@ -193,7 +193,7 @@
 	max_range = 4
 	shell_speed = 3
 	damage = 20
-	penetration = 20
+	penetration = 40
 	damage_falloff = 0
 
 /datum/ammo/bullet/tx54_spread/on_hit_mob(mob/target_mob, obj/projectile/proj)


### PR DESCRIPTION
## `Основные изменения`
слегка меняет код поведения снарядов гл54 и ар55.
бесчестно взял код с офов.

вот как работает сейчас

https://github.com/user-attachments/assets/fac62a69-1ea9-43df-9d38-a2579e64fc40

вот как после фикса (на локалке)

https://github.com/user-attachments/assets/158acb37-ae0d-4f66-92b8-618a81900262

## `Как это улучшит игру`
на данный момент снаряды гл54 и ар55 не дамажат ксен с резист к отталкиванию чего быть не должно.
## `Ченджлог`
```
:cl:
fix: исправленно (возможно) проблема с не проходящим уроном по ксеноморфам с резистом к отталкиванию.
balance: поднятое пробитие брони с 20 до 40 (почти у всего оружия было поднято пробитие но не гл54)
/:cl:
```
